### PR TITLE
Return un-masked value

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ import TextInputMask from 'react-native-text-input-mask';
 ...
 ```
 
+In the following example, the masked value will be returned when `onChangeText` is fired:
+
+```
+<TextInputMask
+    mask={"+1 ([000]) [000] [00] [00]"}
+    onChangeText={(value) => { console.log(value); }
+/>
+// will log `+1 (000) 000 00 00` to the console
+```
+
+If you would like the un-masked value to be returned, you should set the `returnUnmasked`
+prop to `true` as in the following example:
+
+ ```
+<TextInputMask
+    returnUnmasked
+    mask={"+1 ([000]) [000] [00] [00]"}
+    onChangeText={(value) => { console.log(value); }
+/>
+// will log `0000000000` to the console
+```
+
 ## More info
 
 [RedMadRobot Input Mask Android](https://github.com/RedMadRobot/input-mask-android)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import TextInputMask from 'react-native-text-input-mask';
 
 In the following example, the masked value will be returned when `onChangeText` is fired:
 
-```
+```javascript
 <TextInputMask
     mask={"+1 ([000]) [000] [00] [00]"}
     onChangeText={(value) => { console.log(value); }
@@ -37,7 +37,7 @@ In the following example, the masked value will be returned when `onChangeText` 
 If you would like the un-masked value to be returned, you should set the `returnUnmasked`
 prop to `true` as in the following example:
 
- ```
+```javascript
 <TextInputMask
     returnUnmasked
     mask={"+1 ([000]) [000] [00] [00]"}

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ export { mask }
 
 export default class TextInputMask extends Component {
   static defaultProps = {
+    returnMasked: true,
     maskDefaultValue: true,
   }
 
@@ -28,6 +29,7 @@ export default class TextInputMask extends Component {
     if (this.props.mask && !this.masked) {
       this.masked = true
       NativeModules.RNTextInputMask.setMask(findNodeHandle(this.input), this.props.mask)
+      NativeModules.RNTextInputMask.returnMasked(this.props.returnMasked);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ export { mask }
 
 export default class TextInputMask extends Component {
   static defaultProps = {
-    returnMasked: true,
+    returnUnmasked: false,
     maskDefaultValue: true,
   }
 
@@ -29,7 +29,7 @@ export default class TextInputMask extends Component {
     if (this.props.mask && !this.masked) {
       this.masked = true
       NativeModules.RNTextInputMask.setMask(findNodeHandle(this.input), this.props.mask)
-      NativeModules.RNTextInputMask.returnMasked(this.props.returnMasked);
+      NativeModules.RNTextInputMask.returnUnmasked(this.props.returnUnmasked);
     }
   }
 

--- a/ios/RNTextInputMask/RNTextInputMask/RNTextInputMask.m
+++ b/ios/RNTextInputMask/RNTextInputMask/RNTextInputMask.m
@@ -39,11 +39,11 @@ RCT_EXPORT_METHOD(setMask:(nonnull NSNumber *)reactNode mask:(NSString *)mask) {
         dispatch_async(dispatch_get_main_queue(), ^{
             RCTTextField *view = viewRegistry[reactNode];
             RCTUITextField *textView = [view backedTextInputView];
-            
+
             if (!masks) {
                 masks = [[NSMutableDictionary alloc] init];
             }
-            
+
             NSString *key = [NSString stringWithFormat:@"%@", reactNode];
             masks[key] = [[MaskedTextFieldDelegate alloc] initWithFormat:mask];
             [masks[key] setListener:self];

--- a/ios/RNTextInputMask/RNTextInputMask/RNTextInputMask.m
+++ b/ios/RNTextInputMask/RNTextInputMask/RNTextInputMask.m
@@ -18,20 +18,12 @@
 
 @implementation RNTextInputMask {
     NSMutableDictionary *masks;
-    BOOL returnMaskedValue;
+    BOOL returnUnmaskedValue;
 }
 
 @synthesize bridge = _bridge;
 
 RCT_EXPORT_MODULE();
-
-- (instancetype)init {
-    if (self = [super init]) {
-        returnMaskedValue = YES;
-    }
-
-    return self;
-}
 
 - (dispatch_queue_t)methodQueue {
     return self.bridge.uiManager.methodQueue;
@@ -47,11 +39,11 @@ RCT_EXPORT_METHOD(setMask:(nonnull NSNumber *)reactNode mask:(NSString *)mask) {
         dispatch_async(dispatch_get_main_queue(), ^{
             RCTTextField *view = viewRegistry[reactNode];
             RCTUITextField *textView = [view backedTextInputView];
-
+            
             if (!masks) {
                 masks = [[NSMutableDictionary alloc] init];
             }
-
+            
             NSString *key = [NSString stringWithFormat:@"%@", reactNode];
             masks[key] = [[MaskedTextFieldDelegate alloc] initWithFormat:mask];
             [masks[key] setListener:self];
@@ -60,23 +52,23 @@ RCT_EXPORT_METHOD(setMask:(nonnull NSNumber *)reactNode mask:(NSString *)mask) {
     }];
 }
 
-RCT_EXPORT_METHOD(returnMasked:(BOOL)shouldReturnMasked) {
-    returnMaskedValue = shouldReturnMasked;
+RCT_EXPORT_METHOD(returnUnmasked:(BOOL)shouldReturnUnmasked) {
+    returnUnmaskedValue = shouldReturnUnmasked;
 }
 
 - (void)textField:(RCTUITextField *)textField didFillMandatoryCharacters:(BOOL)complete didExtractValue:(NSString *)value
 {
     NSString *returnValue = textField.text;
-
-    if (!returnMaskedValue) {
+    
+    if (returnUnmaskedValue) {
         returnValue = value;
     }
-
+    
     [self.bridge.eventDispatcher sendTextEventWithType:RCTTextEventTypeChange
-                                   reactTag:[[textField reactSuperview] reactTag]
-                                       text:returnValue
-                                        key:nil
-                                 eventCount:1];
+                                              reactTag:[[textField reactSuperview] reactTag]
+                                                  text:returnValue
+                                                   key:nil
+                                            eventCount:1];
 }
 
 

--- a/ios/RNTextInputMask/RNTextInputMask/RNTextInputMask.m
+++ b/ios/RNTextInputMask/RNTextInputMask/RNTextInputMask.m
@@ -18,11 +18,20 @@
 
 @implementation RNTextInputMask {
     NSMutableDictionary *masks;
+    BOOL returnMaskedValue;
 }
 
 @synthesize bridge = _bridge;
 
 RCT_EXPORT_MODULE();
+
+- (instancetype)init {
+    if (self = [super init]) {
+        returnMaskedValue = YES;
+    }
+
+    return self;
+}
 
 - (dispatch_queue_t)methodQueue {
     return self.bridge.uiManager.methodQueue;
@@ -51,11 +60,21 @@ RCT_EXPORT_METHOD(setMask:(nonnull NSNumber *)reactNode mask:(NSString *)mask) {
     }];
 }
 
+RCT_EXPORT_METHOD(returnMasked:(BOOL)shouldReturnMasked) {
+    returnMaskedValue = shouldReturnMasked;
+}
+
 - (void)textField:(RCTUITextField *)textField didFillMandatoryCharacters:(BOOL)complete didExtractValue:(NSString *)value
 {
+    NSString *returnValue = textField.text;
+
+    if (!returnMaskedValue) {
+        returnValue = value;
+    }
+
     [self.bridge.eventDispatcher sendTextEventWithType:RCTTextEventTypeChange
                                    reactTag:[[textField reactSuperview] reactTag]
-                                       text:textField.text
+                                       text:returnValue
                                         key:nil
                                  eventCount:1];
 }


### PR DESCRIPTION
Adds the option of returning the un-masked value when `onTextChange` is fired as per these examples:

```javascript
<TextInputMask
    mask={"+1 ([000]) [000] [00] [00]"}
    onChangeText={(value) => { console.log(value); }
/>
// will log `+1 (000) 000 00 00` to the console
```

 ```javascript
<TextInputMask
    returnUnmasked
    mask={"+1 ([000]) [000] [00] [00]"}
    onChangeText={(value) => { console.log(value); }
/>
// will log `0000000000` to the console
```