### PR TITLE
Verify null ref on setNativeProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,11 @@ export default class TextInputMask extends Component {
     if (this.props.maskDefaultValue &&
         this.props.mask &&
         this.props.value) {
-      mask(this.props.mask, '' + this.props.value, text =>
-        this.input.setNativeProps({ text }),
-      )
+      mask(this.props.mask, '' + this.props.value, text => {
+        if (this.input !== null) {
+          this.input.setNativeProps({ text })
+        }
+      })
     }
 
     if (this.props.mask && !this.masked) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ivanzotov/react-native-text-input-mask"
+    "url": "https://github.com/mypharmabr/react-native-text-input-mask"
   },
   "keywords": [
     "react",
@@ -20,7 +20,6 @@
   ],
   "author": "Ivan Zotov",
   "bugs": {
-    "url": "https://github.com/ivanzotov/react-native-text-input-mask/issues"
-  },
-  "homepage": "http://ivanzotov.com"
+    "url": "https://github.com/mypharmabr/react-native-text-input-mask/issues"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-text-input-mask",
+  "name": "@mypharma/react-native-text-input-mask",
   "version": "0.5.2",
   "description": "Text input mask for React Native on iOS and Android.",
   "main": "index.js",


### PR DESCRIPTION
Fixes #30 

For some reason, when unmounting parent elements, `this.input` becomes `null`.

I don't know if this happens on other contexts where `this.input.setNativeProps` is used and, if so, let me know so I may apply this verification on other places too.