### PR TITLE
Prevent setting a mask on a view that doesn’t exist anymore on Android

### DIFF
--- a/android/src/main/java/com/RNTextInputMask/RNTextInputMaskModule.java
+++ b/android/src/main/java/com/RNTextInputMask/RNTextInputMaskModule.java
@@ -75,7 +75,10 @@ public class RNTextInputMaskModule extends ReactContextBaseJavaModule {
         @Override
         public void run() {
           UIManagerModule uiManager = rctx.getNativeModule(UIManagerModule.class);
-          uiManager.addUIBlock(new UIBlock() {
+
+          // We need to use prependUIBlock instead of addUIBlock since subsequent UI operations in
+          // the queue might be removing the view we're looking to update.
+          uiManager.prependUIBlock(new UIBlock() {
               @Override
               public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
                   EditText editText = (EditText)nativeViewHierarchyManager.resolveView(view);


### PR DESCRIPTION
We’ve seen some crashes due to inconsistencies between JS and native views on Android, I think we managed to track them down. The text input can sometimes be removed from the view hierarchy before the UI block is executed.

```
E/unknown:ReactNative: Exception in native call
                       com.facebook.react.uimanager.IllegalViewOperationException: Trying to resolve view with tag 2970 which doesn't exist
                           at com.facebook.react.uimanager.NativeViewHierarchyManager.resolveView(NativeViewHierarchyManager.java:94)
                           at com.RNTextInputMask.RNTextInputMaskModule$1$1.execute(RNTextInputMaskModule.java:78)
                           at com.facebook.react.uimanager.UIViewOperationQueue$UIBlockOperation.execute(UIViewOperationQueue.java:512)
                           at com.facebook.react.uimanager.UIViewOperationQueue$1.run(UIViewOperationQueue.java:821)
                           at com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches(UIViewOperationQueue.java:928)
                           at com.facebook.react.uimanager.UIViewOperationQueue.access$2100(UIViewOperationQueue.java:46)
                           at com.facebook.react.uimanager.UIViewOperationQueue$DispatchUIFrameCallback.doFrameGuarded(UIViewOperationQueue.java:988)
                           at com.facebook.react.uimanager.GuardedFrameCallback.doFrame(GuardedFrameCallback.java:29)
                           at com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame(ReactChoreographer.java:134)
                           at com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame(ChoreographerCompat.java:105)
                           at android.view.Choreographer$CallbackRecord.run(Choreographer.java:872)
                           at android.view.Choreographer.doCallbacks(Choreographer.java:686)
                           at android.view.Choreographer.doFrame(Choreographer.java:618)
                           at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:860)
                           at android.os.Handler.handleCallback(Handler.java:751)
                           at android.os.Handler.dispatchMessage(Handler.java:95)
                           at android.os.Looper.loop(Looper.java:154)
                           at android.app.ActivityThread.main(ActivityThread.java:6121)
                           at java.lang.reflect.Method.invoke(Native Method)
                           at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
                           at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
```