### PR TITLE
disable multiline when mask is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ export default class TextInputMask extends Component {
           this.props.refInput(ref)
         }
       }}
+      multiline={this.props.mask ? false : this.props.multiline}
       onChangeText={masked => {
         if (this.props.mask) {
           const _unmasked = unmask(this.props.mask, masked, unmasked => {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ import React, { Component } from 'react'
 import {
   TextInput,
   findNodeHandle,
-  NativeModules
+  NativeModules,
+  Platform
 } from 'react-native'
 
 const mask = NativeModules.RNTextInputMask.mask
@@ -55,7 +56,7 @@ export default class TextInputMask extends Component {
           this.props.refInput(ref)
         }
       }}
-      multiline={this.props.mask ? false : this.props.multiline}
+      multiline={this.props.mask && Platform.OS === 'ios' ? false : this.props.multiline}
       onChangeText={masked => {
         if (this.props.mask) {
           const _unmasked = unmask(this.props.mask, masked, unmasked => {


### PR DESCRIPTION
Prevent mask from silently failing if multiline is true. Only is an issue on iOS.