### PR TITLE
Android backspace - fix

### DIFF
--- a/android/src/main/java/com/RNTextInputMask/RNTextInputMaskModule.java
+++ b/android/src/main/java/com/RNTextInputMask/RNTextInputMaskModule.java
@@ -43,7 +43,7 @@ public class RNTextInputMaskModule extends ReactContextBaseJavaModule {
               input,
               input.length()
           ),
-          true
+          false 
       );
       final String output = result.getFormattedText().getString();
       onResult.invoke(output);


### PR DESCRIPTION
I have faced the issue which is easier to show, than describe

![backspace problem](https://user-images.githubusercontent.com/26224268/46867685-ef1cd480-ce36-11e8-9286-58a765a31e71.gif)

I am not a java guy at all, but there was one with the same problem
https://github.com/RedMadRobot/input-mask-android/issues/60
https://github.com/react-native-community/react-native-text-input-mask/issues/71

Setting autocomplete to false actually solves that problem, like he said.
Can we accept this changes to fix so sad problem? Because it makes this kind of text-masks unusable.
