### PR TITLE
Fix Cursor bug in Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,5 +19,6 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.redmadrobot:inputmask:2.3.0'
+    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.3.0'
+    compile 'com.redmadrobot:inputmask:3.4.4'
 }


### PR DESCRIPTION
So there is a bug related to the cursor, where it keeps jumping to start and adding the letters at the start of the input, described at #48 

This PR tries to fix it by using a comment that fixed it for myself, which is just bumping the version from  `com.redmadrobot:inputmask:2.3.0` to `com.redmadrobot:inputmask:3.4.4` and another dependency which is `org.jetbrains.kotlin:kotlin-stdlib:1.3.0`

I can't confirm that there are no side effects, but in my use case it fixed all the problems and behaving the same way.