### PR TITLE
remove unused NonNull import

### DIFF
--- a/android/src/main/java/com/RNTextInputMask/RNTextInputMaskModule.java
+++ b/android/src/main/java/com/RNTextInputMask/RNTextInputMaskModule.java
@@ -17,7 +17,6 @@ import com.redmadrobot.inputmask.PolyMaskTextChangedListener;
 
 import com.redmadrobot.inputmask.model.CaretString;
 import com.redmadrobot.inputmask.helper.Mask;
-import android.support.annotation.NonNull;
 
 public class RNTextInputMaskModule extends ReactContextBaseJavaModule {
     ReactApplicationContext reactContext;


### PR DESCRIPTION
this unused import prevents this lib from being compatible with Android projects that are using AndroidX (see https://developer.android.com/jetpack/androidx/) instead of the old support package labelling

so here's a simple fix for that

fixes: https://github.com/react-native-community/react-native-text-input-mask/issues/97