### PR TITLE
Issue #65 - Fixed RNTextInputMaskModule.java getTag/setTag calls to u…

### DIFF
--- a/android/src/main/java/com/RNTextInputMask/RNTextInputMaskModule.java
+++ b/android/src/main/java/com/RNTextInputMask/RNTextInputMaskModule.java
@@ -20,6 +20,11 @@ import com.redmadrobot.inputmask.helper.Mask;
 import android.support.annotation.NonNull;
 
 public class RNTextInputMaskModule extends ReactContextBaseJavaModule {
+
+    private static final int TEXT_CHANGE_LISTENER_TAG_KEY = 123456789;
+
+
+
     ReactApplicationContext reactContext;
 
     public RNTextInputMaskModule(ReactApplicationContext reactContext) {
@@ -88,11 +93,11 @@ public class RNTextInputMaskModule extends ReactContextBaseJavaModule {
                                 null
                         );
 
-                        if (editText.getTag() != null) {
-                            editText.removeTextChangedListener((TextWatcher) editText.getTag());
+                        if (editText.getTag(TEXT_CHANGE_LISTENER_TAG_KEY) != null) {
+                            editText.removeTextChangedListener((TextWatcher) editText.getTag(TEXT_CHANGE_LISTENER_TAG_KEY));
                         }
 
-                        editText.setTag(listener);
+                        editText.setTag(TEXT_CHANGE_LISTENER_TAG_KEY, listener);
                         editText.addTextChangedListener(listener);
                     }
                 });


### PR DESCRIPTION
Fixed the `RNTextInputMaskModule.java` `getTag(..)` / `setTag(..)` logic for removing the previous text changed listener to use a new `TEXT_CHANGE_LISTENER_TAG_KEY` property for the tag key.

This resolves issue #65 